### PR TITLE
Arreglar inicio

### DIFF
--- a/frontend/src/Pagina/Inicio.jsx
+++ b/frontend/src/Pagina/Inicio.jsx
@@ -1,13 +1,11 @@
-import { useNombres } from "../Hooks/obtenerNombres";
 import { useObtenerTonto } from "../Hooks/useObtenerTonto";
 import Tarjeta from "../Componentes/Tarjeta/Tarjeta";
 import Carga from "./Errores/Carga";
 
 const Inicio = () => {
-  const { cargaa } = useNombres();
-  const { tonto } = useObtenerTonto();
+  const { tonto, carga } = useObtenerTonto();
 
-  if (cargaa) {
+  if (carga) {
     return <Carga />;
   }
 


### PR DESCRIPTION
## Errores en el inicio

Error 1: pedir nombres que no son necesarios.

Error 2: se usaba la variable carga de un hook y se usaban los datos de otro hook distinto.


## Soluciones

Solucion 1: Borrar el uso del hook que no es necesario y solo dejar al hook que es necesario.

Solucion 2: Usar la carga y los datos del mismo hook.
