### PR TITLE
Convertir columna dia en tipo fecha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "crypto": "^1.0.1",
-        "dayjs": "^1.11.10",
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "express-rate-limit": "^7.2.0",
@@ -203,11 +202,6 @@
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
       "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "crypto": "^1.0.1",
-    "dayjs": "^1.11.10",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "express-rate-limit": "^7.2.0",

--- a/server/tontos/tontos.service.js
+++ b/server/tontos/tontos.service.js
@@ -1,30 +1,18 @@
-const dayjs = require('dayjs');
-
 const tontoRepository = require('./tontos.repository');
-
-function getTodayString() {
-  const date = new Date();
-  return getDateString(date);
-}
-
-function getDateString(date) {
-  return dayjs(date).format('DD/MM/YYYY');
-}
 
 async function saveTodays(cowboyId) {
   const date = new Date();
-  const strToday = getDateString(date);
-  const today = await tontoRepository.getTontoByDate(strToday);
+  const today = await tontoRepository.getTontoByDate(date);
   if (today) return today;
 
-  await tontoRepository.saveTonto(strToday, cowboyId, date);
+  await tontoRepository.saveTonto(date, cowboyId, new Date());
 
   return await tontoRepository.getTontoById(cowboyId)
 }
 
 async function getToday() {
-  const strToday = getTodayString();
-  return await tontoRepository.getTontoByDate(strToday);
+  const date = new Date();
+  return await tontoRepository.getTontoByDate(date);
 }
 
 async function getTontoById(idCowboy) {

--- a/sql/010_update_dia_column.sql
+++ b/sql/010_update_dia_column.sql
@@ -12,3 +12,6 @@ ALTER TABLE tontos RENAME COLUMN dia_temp TO dia;
 
 -- Paso 5: Establecer la nueva columna dia como no nula
 ALTER TABLE tontos ALTER COLUMN dia SET NOT NULL;
+
+-- Paso 6: Establecer la nueva columna dia como única
+ALTER TABLE tontos ADD UNIQUE (dia);

--- a/sql/010_update_dia_column.sql
+++ b/sql/010_update_dia_column.sql
@@ -1,14 +1,14 @@
--- Step 1: Add a new column dia_temp with date type
+-- Paso 1: Agregar una nueva columna dia_temp con tipo de dato date
 ALTER TABLE tontos ADD COLUMN dia_temp DATE;
 
--- Step 2: Set the values of dia_temp from dia
+-- Paso 2: Establecer los valores de dia_temp a partir de dia
 UPDATE tontos SET dia_temp = TO_DATE(dia, 'DD/MM/YYYY');
 
--- Step 3: Drop the old dia column
+-- Paso 3: Eliminar la antigua columna dia
 ALTER TABLE tontos DROP COLUMN dia;
 
--- Step 4: Rename dia_temp to dia
+-- Paso 4: Renombrar dia_temp a dia
 ALTER TABLE tontos RENAME COLUMN dia_temp TO dia;
 
--- Step 5: Set the new dia column to non-nullable
+-- Paso 5: Establecer la nueva columna dia como no nula
 ALTER TABLE tontos ALTER COLUMN dia SET NOT NULL;

--- a/sql/010_update_dia_column.sql
+++ b/sql/010_update_dia_column.sql
@@ -1,0 +1,14 @@
+-- Step 1: Add a new column dia_temp with date type
+ALTER TABLE tontos ADD COLUMN dia_temp DATE;
+
+-- Step 2: Set the values of dia_temp from dia
+UPDATE tontos SET dia_temp = TO_DATE(dia, 'DD/MM/YYYY');
+
+-- Step 3: Drop the old dia column
+ALTER TABLE tontos DROP COLUMN dia;
+
+-- Step 4: Rename dia_temp to dia
+ALTER TABLE tontos RENAME COLUMN dia_temp TO dia;
+
+-- Step 5: Set the new dia column to non-nullable
+ALTER TABLE tontos ALTER COLUMN dia SET NOT NULL;


### PR DESCRIPTION
## Cambios

 - Cambia la columna `dia` al tipo `date` (fecha) con un nuevo script SQL.
 - Simplifica el codigo del servicio para que tome ventaja de la nueva columna.
 - Borra la libreria `dayjs` que ya no es necesaria.

## Como revisar

- Ignorar los cambios en `package-lock.json`
- Verificar que `dayjs` fue eliminada de `package.json`
- Revisar los cambios en `tontos.service.js`
- Revisar el nuevo archivo SQL.