### PR TITLE
API de calendario recibe rango de fechas

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -20,8 +20,8 @@ router.delete("/titulos/:idTitulo", standardAuth, titulosController.deleteTitulo
 router.post("/tontos", sudoAuth, tontosController.createTontoHoy);
 // Obtener tonto del dia
 router.get("/tontos/hoy", tontosController.getTontoHoy);
-// Obtener tontos del mes
-router.get("/tontos/:year/:month", tontosController.getTontosMes);
+// Obtener calendario de tontos entre dos fechas
+router.get("/tontos/calendario", tontosController.getTontosPorRango);
 // Obtener tonto por id
 router.get("/tontos/:idCowboy", tontosController.getTontoPorId);
 // Obtener todos los tontos

--- a/server/tontos/tontos.controller.js
+++ b/server/tontos/tontos.controller.js
@@ -49,12 +49,26 @@ async function getTontoHoy(_, res) {
   }
 }
 
-async function getTontosMes(req, res) {
+async function getTontosPorRango(req, res) {
   try {
-    const year = parseInt(req.params.year);
-    const month = parseInt(req.params.month);
+    const inicio = req.query.inicio;
+    const fin = req.query.fin;
 
-    const tontos = await tontosService.getTontoByMes(year, month);
+    console.log("inicio", inicio, "fin", fin);
+
+    if (!inicio) {
+      return res.status(400).json({
+        message: `Falta el parámetro de 'inicio' en la URL`,
+      });
+    }
+
+    if (!fin) {
+      return res.status(400).json({
+        message: `Falta el parámetro de 'fin' en la URL`,
+      });
+    }
+
+    const tontos = await tontosService.getTontosPorRango(inicio, fin);
     return res.json(tontos);
   } catch (err) {
     console.error(err);
@@ -82,5 +96,5 @@ module.exports = {
   getTontoHoy,
   getAllTontos,
   getTontoPorId,
-  getTontosMes,
+  getTontosPorRango,
 };

--- a/server/tontos/tontos.service.js
+++ b/server/tontos/tontos.service.js
@@ -10,10 +10,10 @@ async function saveTodays(cowboyId) {
   return await tontoRepository.getTontoById(cowboyId)
 }
 
-async function getTontoByMes(year, month) {
-  const startOfMonth = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0, 0));
-  const endOfMonth = new Date(Date.UTC(year, month, 0, 23, 59, 59, 999));
-  return await tontoRepository.getTontoByPeriod(startOfMonth, endOfMonth);
+async function getTontosPorRango(inicio, fin) {
+  const start = new Date(inicio);
+  const end = new Date(fin);
+  return await tontoRepository.getTontoByPeriod(start, end);
 }
 
 async function getToday() {
@@ -30,7 +30,7 @@ async function getAll() {
 }
 
 module.exports = {
-  getTontoByMes,
+  getTontosPorRango,
   getTontoById,
   saveTodays,
   getToday,


### PR DESCRIPTION
## Cambio 

Ahora la API para obtener el historial de tontos usa un rango de fechas.

La URL es un `GET https://thecowboys.duckdns.org/api/tontos/calendario`
Que recibe dos query params:
 - `inicio`
 - `fin`

Ejemplo:

```
GET /api/tontos/calendario?inicio=2024-05-01T00:00:00.000Z&fin=2024-05-05T23:59:59.999Z
```